### PR TITLE
Make AudioLoader class and add usage example

### DIFF
--- a/GDScriptAudioImport.gd
+++ b/GDScriptAudioImport.gd
@@ -24,7 +24,7 @@
 
 #I honestly don't care that much, Kopimi ftw, but it's my little baby and I want it to look nice :3
 
-extends Node
+class_name AudioLoader
 
 func report_errors(err, filepath):
 	# See: https://docs.godotengine.org/en/latest/classes/class_@globalscope.html#enum-globalscope-error

--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@ A script for Godot in GDScript for importing .wav (via parsing the wav header), 
 
 I'm sure there's way more efficient ways to do this, but for me this works so far and it's my little baby.
 
+
+# Usage instructions and example
+1. Import the script in to your project
+2. When you want to load you can call the class:
+```
+var music = AudioStreamPlayer.new()
+var audio_loader = AudioLoader.new()
+music.set_stream(audio_loader.loadfile("/path/to/song.ogg"))
+music.volume_db = 1
+music.pitch_scale = 1
+music.play()
+```
+
 ### TODO:
 
 0. Test with very different wav files in order to see if format parsing works for different chunk sizes (doesn't seem to)


### PR DESCRIPTION
Hey,
This way,
1. You don't need to even load the gd script, it is detected automatically in your project.
2. You don't need to attach the script to a node or something like that.
3. Its a good grounds to add this to the assetlib and all you do is install the asset and it all works.
4. I added a usage example because I could not find one.