### PR TITLE
Add support for wav files with data bytes starting from byte 100+

### DIFF
--- a/GDScriptAudioImport.gd
+++ b/GDScriptAudioImport.gd
@@ -64,8 +64,8 @@ func loadfile(filepath):
 		#parrrrseeeeee!!! :D
 		
 		var bits_per_sample = 0
-		
-		for i in range(0, 100):
+		var i = 0
+		while true:
 			var those4bytes = str(char(bytes[i])+char(bytes[i+1])+char(bytes[i+2])+char(bytes[i+3]))
 			
 			if those4bytes == "RIFF": 
@@ -136,6 +136,10 @@ func loadfile(filepath):
 					newstream.data = convert_to_16bit(data, bits_per_sample)
 				else:
 					newstream.data = data
+				
+				break # the data will be at the end, end searching here
+			
+			i += 1
 			# end of parsing
 			#---------------------------
 

--- a/GDScriptAudioImport.gd
+++ b/GDScriptAudioImport.gd
@@ -66,6 +66,10 @@ func loadfile(filepath):
 		var bits_per_sample = 0
 		var i = 0
 		while true:
+			if i >= len(bytes) - 4: # Failsafe, if there is no data bytes
+				print("Data byte not found")
+				break
+				
 			var those4bytes = str(char(bytes[i])+char(bytes[i+1])+char(bytes[i+2])+char(bytes[i+3]))
 			
 			if those4bytes == "RIFF": 


### PR DESCRIPTION
The `for i in range(0, 100)` when parsing .wav files is problematic when the Audio data starts at byte 100+. Using while loop to indefinitely search for the "data" bytes, this will be mitigated. In my case, the "data" byte is located at byte 122, which can be fixed by changing the range from `0, 100` to `0, 200`, but I thought not depending on fixed values is better. 

A fail-safe is in place if the .wav file were to somehow not have the "data" bytes which is unlikely since it's an integral part of the file.